### PR TITLE
Update plugin classic-editor

### DIFF
--- a/Plugin/classic-editor/LICENSE.md
+++ b/Plugin/classic-editor/LICENSE.md
@@ -1,0 +1,400 @@
+### WordPress - Web publishing software
+
+    Copyright 2011-2019 by the contributors
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+This program incorporates work covered by the following copyright and
+permission notices:
+
+    b2 is (c) 2001, 2002 Michel Valdrighi - m@tidakada.com -
+    http://tidakada.com
+
+    Wherever third party code has been used, credit has been given in the code's
+    comments.
+
+    b2 is released under the GPL
+
+and
+
+    WordPress - Web publishing software
+
+    Copyright 2003-2010 by the contributors
+
+    WordPress is released under the GPL
+  
+---
+
+### GNU GENERAL PUBLIC LICENSE
+
+Version 2, June 1991
+
+    Copyright (C) 1989, 1991 Free Software Foundation, Inc.  
+    51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+    Everyone is permitted to copy and distribute verbatim copies
+    of this license document, but changing it is not allowed.
+
+### Preamble
+
+The licenses for most software are designed to take away your freedom
+to share and change it. By contrast, the GNU General Public License is
+intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users. This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it. (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.) You can apply it to
+your programs, too.
+
+When we speak of free software, we are referring to freedom, not
+price. Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if
+you distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have. You must make sure that they, too, receive or can get the
+source code. And you must show them these terms so they know their
+rights.
+
+We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software. If the software is modified by someone else and passed on,
+we want its recipients to know that what they have is not the
+original, so that any problems introduced by others will not reflect
+on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software
+patents. We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary. To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at
+all.
+
+The precise terms and conditions for copying, distribution and
+modification follow.
+
+### TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+**0.** This License applies to any program or other work which
+contains a notice placed by the copyright holder saying it may be
+distributed under the terms of this General Public License. The
+"Program", below, refers to any such program or work, and a "work
+based on the Program" means either the Program or any derivative work
+under copyright law: that is to say, a work containing the Program or
+a portion of it, either verbatim or with modifications and/or
+translated into another language. (Hereinafter, translation is
+included without limitation in the term "modification".) Each licensee
+is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope. The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the Program
+(independent of having been made by running the Program). Whether that
+is true depends on what the Program does.
+
+**1.** You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a
+fee.
+
+**2.** You may modify your copy or copies of the Program or any
+portion of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+  
+**a)** You must cause the modified files to carry prominent notices
+stating that you changed the files and the date of any change.
+
+  
+**b)** You must cause any work that you distribute or publish, that in
+whole or in part contains or is derived from the Program or any part
+thereof, to be licensed as a whole at no charge to all third parties
+under the terms of this License.
+
+  
+**c)** If the modified program normally reads commands interactively
+when run, you must cause it, when started running for such interactive
+use in the most ordinary way, to print or display an announcement
+including an appropriate copyright notice and a notice that there is
+no warranty (or else, saying that you provide a warranty) and that
+users may redistribute the program under these conditions, and telling
+the user how to view a copy of this License. (Exception: if the
+Program itself is interactive but does not normally print such an
+announcement, your work based on the Program is not required to print
+an announcement.)
+
+These requirements apply to the modified work as a whole. If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works. But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+**3.** You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+  
+**a)** Accompany it with the complete corresponding machine-readable
+source code, which must be distributed under the terms of Sections 1
+and 2 above on a medium customarily used for software interchange; or,
+
+  
+**b)** Accompany it with a written offer, valid for at least three
+years, to give any third party, for a charge no more than your cost of
+physically performing source distribution, a complete machine-readable
+copy of the corresponding source code, to be distributed under the
+terms of Sections 1 and 2 above on a medium customarily used for
+software interchange; or,
+
+  
+**c)** Accompany it with the information you received as to the offer
+to distribute corresponding source code. (This alternative is allowed
+only for noncommercial distribution and only if you received the
+program in object code or executable form with such an offer, in
+accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it. For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable. However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+**4.** You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License. Any attempt otherwise
+to copy, modify, sublicense or distribute the Program is void, and
+will automatically terminate your rights under this License. However,
+parties who have received copies, or rights, from you under this
+License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+**5.** You are not required to accept this License, since you have not
+signed it. However, nothing else grants you permission to modify or
+distribute the Program or its derivative works. These actions are
+prohibited by law if you do not accept this License. Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+**6.** Each time you redistribute the Program (or any work based on
+the Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions. You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+**7.** If, as a consequence of a court judgment or allegation of
+patent infringement or for any other reason (not limited to patent
+issues), conditions are imposed on you (whether by court order,
+agreement or otherwise) that contradict the conditions of this
+License, they do not excuse you from the conditions of this License.
+If you cannot distribute so as to satisfy simultaneously your
+obligations under this License and any other pertinent obligations,
+then as a consequence you may not distribute the Program at all. For
+example, if a patent license would not permit royalty-free
+redistribution of the Program by all those who receive copies directly
+or indirectly through you, then the only way you could satisfy both it
+and this License would be to refrain entirely from distribution of the
+Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices. Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+**8.** If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded. In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+**9.** The Free Software Foundation may publish revised and/or new
+versions of the General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation. If the Program does not specify a
+version number of this License, you may choose any version ever
+published by the Free Software Foundation.
+
+**10.** If you wish to incorporate parts of the Program into other
+free programs whose distribution conditions are different, write to
+the author to ask for permission. For software which is copyrighted by
+the Free Software Foundation, write to the Free Software Foundation;
+we sometimes make exceptions for this. Our decision will be guided by
+the two goals of preserving the free status of all derivatives of our
+free software and of promoting the sharing and reuse of software
+generally.
+
+**NO WARRANTY**
+
+**11.** BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+**12.** IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+### END OF TERMS AND CONDITIONS
+
+### How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these
+terms.
+
+To do so, attach the following notices to the program. It is safest to
+attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    one line to give the program's name and an idea of what it does.
+    Copyright (C) yyyy  name of author
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+Also add information on how to contact you by electronic and paper
+mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
+    type `show w'.  This is free software, and you are welcome
+    to redistribute it under certain conditions; type `show c' 
+    for details.
+
+The hypothetical commands \`show w' and \`show c' should show the
+appropriate parts of the General Public License. Of course, the
+commands you use may be called something other than \`show w' and
+\`show c'; they could even be mouse-clicks or menu items--whatever
+suits your program.
+
+You should also get your employer (if you work as a programmer) or
+your school, if any, to sign a "copyright disclaimer" for the program,
+if necessary. Here is a sample; alter the names:
+
+    Yoyodyne, Inc., hereby disclaims all copyright
+    interest in the program `Gnomovision'
+    (which makes passes at compilers) written 
+    by James Hacker.
+
+    signature of Ty Coon, 1 April 1989
+    Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program
+into proprietary programs. If your program is a subroutine library,
+you may consider it more useful to permit linking proprietary
+applications with the library. If this is what you want to do, use the
+[GNU Lesser General Public
+License](http://www.gnu.org/licenses/lgpl.html) instead of this
+License.

--- a/Plugin/classic-editor/classic-editor.php
+++ b/Plugin/classic-editor/classic-editor.php
@@ -1,0 +1,977 @@
+<?php
+/**
+ * Classic Editor
+ *
+ * Plugin Name: Classic Editor
+ * Plugin URI:  https://wordpress.org/plugins/classic-editor/
+ * Description: Enables the WordPress classic editor and the old-style Edit Post screen with TinyMCE, Meta Boxes, etc. Supports the older plugins that extend this screen.
+ * Version:     1.6.3
+ * Author:      WordPress Contributors
+ * Author URI:  https://github.com/WordPress/classic-editor/
+ * License:     GPLv2 or later
+ * License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: classic-editor
+ * Domain Path: /languages
+ * Requires at least: 4.9
+ * Requires PHP: 5.2.4
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License version 2, as published by the Free Software Foundation. You may NOT assume
+ * that you can use any other version of the GPL.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Invalid request.' );
+}
+
+if ( ! class_exists( 'Classic_Editor' ) ) :
+class Classic_Editor {
+	private static $settings;
+	private static $supported_post_types = array();
+
+	private function __construct() {}
+
+	public static function init_actions() {
+		$block_editor = has_action( 'enqueue_block_assets' );
+		$gutenberg = function_exists( 'gutenberg_register_scripts_and_styles' );
+
+		register_activation_hook( __FILE__, array( __CLASS__, 'activate' ) );
+
+		$settings = self::get_settings();
+
+		if ( is_multisite() ) {
+			add_action( 'wpmu_options', array( __CLASS__, 'network_settings' ) );
+			add_action( 'update_wpmu_options', array( __CLASS__, 'save_network_settings' ) );
+		}
+
+		if ( ! $settings['hide-settings-ui'] ) {
+			// Add a link to the plugin's settings and/or network admin settings in the plugins list table.
+			add_filter( 'plugin_action_links', array( __CLASS__, 'add_settings_link' ), 10, 2 );
+			add_filter( 'network_admin_plugin_action_links', array( __CLASS__, 'add_settings_link' ), 10, 2 );
+
+			add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
+
+			if ( $settings['allow-users'] ) {
+				// User settings.
+				add_action( 'personal_options_update', array( __CLASS__, 'save_user_settings' ) );
+				add_action( 'profile_personal_options', array( __CLASS__, 'user_settings' ) );
+			}
+		}
+
+		// Always remove the "Try Gutenberg" dashboard widget. See https://core.trac.wordpress.org/ticket/44635.
+		remove_action( 'try_gutenberg_panel', 'wp_try_gutenberg_panel' );
+
+		if ( ! $block_editor && ! $gutenberg  ) {
+			return;
+		}
+
+		if ( $settings['allow-users'] ) {
+			// Also used in Gutenberg.
+			add_filter( 'use_block_editor_for_post', array( __CLASS__, 'choose_editor' ), 100, 2 );
+
+			if ( $gutenberg ) {
+				// Support older Gutenberg versions.
+				add_filter( 'gutenberg_can_edit_post', array( __CLASS__, 'choose_editor' ), 100, 2 );
+
+				if ( $settings['editor'] === 'classic' ) {
+					self::remove_gutenberg_hooks( 'some' );
+				}
+			}
+
+			add_filter( 'get_edit_post_link', array( __CLASS__, 'get_edit_post_link' ) );
+			add_filter( 'redirect_post_location', array( __CLASS__, 'redirect_location' ) );
+			add_action( 'edit_form_top', array( __CLASS__, 'add_redirect_helper' ) );
+			add_action( 'admin_head-edit.php', array( __CLASS__, 'add_edit_php_inline_style' ) );
+
+			add_action( 'edit_form_top', array( __CLASS__, 'remember_classic_editor' ) );
+
+			if ( version_compare( $GLOBALS['wp_version'], '5.8', '>=' ) ) {
+				add_filter( 'block_editor_settings_all', array( __CLASS__, 'remember_block_editor' ), 10, 2 );
+			} else {
+				add_filter( 'block_editor_settings', array( __CLASS__, 'remember_block_editor' ), 10, 2 );
+			}
+
+			// Post state (edit.php)
+			add_filter( 'display_post_states', array( __CLASS__, 'add_post_state' ), 10, 2 );
+			// Row actions (edit.php)
+			add_filter( 'page_row_actions', array( __CLASS__, 'add_edit_links' ), 15, 2 );
+			add_filter( 'post_row_actions', array( __CLASS__, 'add_edit_links' ), 15, 2 );
+
+			// Switch editors while editing a post
+			add_action( 'add_meta_boxes', array( __CLASS__, 'add_meta_box' ), 10, 2 );
+			add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_scripts' ) );
+		} else {
+			if ( $settings['editor'] === 'classic' ) {
+				// Also used in Gutenberg.
+				// Consider disabling other Block Editor functionality.
+				add_filter( 'use_block_editor_for_post_type', '__return_false', 100 );
+
+				if ( $gutenberg ) {
+					// Support older Gutenberg versions.
+					add_filter( 'gutenberg_can_edit_post_type', '__return_false', 100 );
+					self::remove_gutenberg_hooks();
+				}
+			} else {
+				// $settings['editor'] === 'block', nothing to do :)
+				return;
+			}
+		}
+
+		if ( $block_editor ) {
+			// Move the Privacy Page notice back under the title.
+			add_action( 'admin_init', array( __CLASS__, 'on_admin_init' ) );
+		}
+		if ( $gutenberg ) {
+			// These are handled by this plugin. All are older, not used in 5.3+.
+			remove_action( 'admin_init', 'gutenberg_add_edit_link_filters' );
+			remove_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_button' );
+			remove_filter( 'redirect_post_location', 'gutenberg_redirect_to_classic_editor_when_saving_posts' );
+			remove_filter( 'display_post_states', 'gutenberg_add_gutenberg_post_state' );
+			remove_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_posts' );
+		}
+	}
+
+	public static function remove_gutenberg_hooks( $remove = 'all' ) {
+		remove_action( 'admin_menu', 'gutenberg_menu' );
+		remove_action( 'admin_init', 'gutenberg_redirect_demo' );
+
+		if ( $remove !== 'all' ) {
+			return;
+		}
+
+		// Gutenberg 5.3+
+		remove_action( 'wp_enqueue_scripts', 'gutenberg_register_scripts_and_styles' );
+		remove_action( 'admin_enqueue_scripts', 'gutenberg_register_scripts_and_styles' );
+		remove_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
+		remove_action( 'rest_api_init', 'gutenberg_register_rest_widget_updater_routes' );
+		remove_action( 'admin_print_styles', 'gutenberg_block_editor_admin_print_styles' );
+		remove_action( 'admin_print_scripts', 'gutenberg_block_editor_admin_print_scripts' );
+		remove_action( 'admin_print_footer_scripts', 'gutenberg_block_editor_admin_print_footer_scripts' );
+		remove_action( 'admin_footer', 'gutenberg_block_editor_admin_footer' );
+		remove_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );
+		remove_action( 'admin_notices', 'gutenberg_build_files_notice' );
+
+		remove_filter( 'load_script_translation_file', 'gutenberg_override_translation_file' );
+		remove_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
+		remove_filter( 'default_content', 'gutenberg_default_demo_content' );
+		remove_filter( 'default_title', 'gutenberg_default_demo_title' );
+		remove_filter( 'block_editor_settings', 'gutenberg_legacy_widget_settings' );
+		remove_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result' );
+
+		// Previously used, compat for older Gutenberg versions.
+		remove_filter( 'wp_refresh_nonces', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );
+		remove_filter( 'get_edit_post_link', 'gutenberg_revisions_link_to_editor' );
+		remove_filter( 'wp_prepare_revision_for_js', 'gutenberg_revisions_restore' );
+
+		remove_action( 'rest_api_init', 'gutenberg_register_rest_routes' );
+		remove_action( 'rest_api_init', 'gutenberg_add_taxonomy_visibility_field' );
+		remove_filter( 'registered_post_type', 'gutenberg_register_post_prepare_functions' );
+
+		remove_action( 'do_meta_boxes', 'gutenberg_meta_box_save' );
+		remove_action( 'submitpost_box', 'gutenberg_intercept_meta_box_render' );
+		remove_action( 'submitpage_box', 'gutenberg_intercept_meta_box_render' );
+		remove_action( 'edit_page_form', 'gutenberg_intercept_meta_box_render' );
+		remove_action( 'edit_form_advanced', 'gutenberg_intercept_meta_box_render' );
+		remove_filter( 'redirect_post_location', 'gutenberg_meta_box_save_redirect' );
+		remove_filter( 'filter_gutenberg_meta_boxes', 'gutenberg_filter_meta_boxes' );
+
+		remove_filter( 'body_class', 'gutenberg_add_responsive_body_class' );
+		remove_filter( 'admin_url', 'gutenberg_modify_add_new_button_url' ); // old
+		remove_action( 'admin_enqueue_scripts', 'gutenberg_check_if_classic_needs_warning_about_blocks' );
+		remove_filter( 'register_post_type_args', 'gutenberg_filter_post_type_labels' );
+
+		// phpcs:disable Squiz.PHP.CommentedOutCode.Found
+		// Keep
+		// remove_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowedtags', 10, 2 ); // not needed in 5.0
+		// remove_filter( 'bulk_actions-edit-wp_block', 'gutenberg_block_bulk_actions' );
+		// remove_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support' );
+		// remove_filter( 'the_content', 'do_blocks', 9 );
+		// remove_action( 'init', 'gutenberg_register_post_types' );
+
+		// Continue to manage wpautop for posts that were edited in Gutenberg.
+		// remove_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
+		// remove_filter( 'the_content', 'gutenberg_wpautop', 8 );
+		// phpcs:enable Squiz.PHP.CommentedOutCode.Found
+
+	}
+
+	private static function get_settings( $refresh = 'no' ) {
+		/**
+		 * Can be used to override the plugin's settings. Always hides the settings UI when used (as users cannot change the settings).
+		 *
+		 * Has to return an associative array with two keys.
+		 * The defaults are:
+		 *   'editor' => 'classic', // Accepted values: 'classic', 'block'.
+		 *   'allow-users' => false,
+		 *
+		 * @param boolean To override the settings return an array with the above keys.
+		 */
+		$settings = apply_filters( 'classic_editor_plugin_settings', false );
+
+		if ( is_array( $settings ) ) {
+			return array(
+				'editor' => ( isset( $settings['editor'] ) && $settings['editor'] === 'block' ) ? 'block' : 'classic',
+				'allow-users' => ! empty( $settings['allow-users'] ),
+				'hide-settings-ui' => true,
+			);
+		}
+
+		if ( ! empty( self::$settings ) && $refresh === 'no' ) {
+			return self::$settings;
+		}
+
+		if ( is_multisite() ) {
+			$defaults = array(
+				'editor' => get_network_option( null, 'classic-editor-replace' ) === 'block' ? 'block' : 'classic',
+				'allow-users' => false,
+			);
+
+			/**
+			 * Filters the default network options.
+			 *
+			 * @param array $defaults The default options array. See `classic_editor_plugin_settings` for supported keys and values.
+			 */
+			$defaults = apply_filters( 'classic_editor_network_default_settings', $defaults );
+
+			if ( get_network_option( null, 'classic-editor-allow-sites' ) !== 'allow' ) {
+				// Per-site settings are disabled. Return default network options nad hide the settings UI.
+				$defaults['hide-settings-ui'] = true;
+				return $defaults;
+			}
+
+			// Override with the site options.
+			$editor_option = get_option( 'classic-editor-replace' );
+			$allow_users_option = get_option( 'classic-editor-allow-users' );
+
+			if ( $editor_option ) {
+				$defaults['editor'] = $editor_option;
+			}
+			if ( $allow_users_option ) {
+				$defaults['allow-users'] = ( $allow_users_option === 'allow' );
+			}
+
+			$editor = ( isset( $defaults['editor'] ) && $defaults['editor'] === 'block' ) ? 'block' : 'classic';
+			$allow_users = ! empty( $defaults['allow-users'] );
+		} else {
+			$allow_users = ( get_option( 'classic-editor-allow-users' ) === 'allow' );
+			$option = get_option( 'classic-editor-replace' );
+
+			// Normalize old options.
+			if ( $option === 'block' || $option === 'no-replace' ) {
+				$editor = 'block';
+			} else {
+				// empty( $option ) || $option === 'classic' || $option === 'replace'
+				$editor = 'classic';
+			}
+		}
+
+		// Override the defaults with the user options.
+		if ( ( ! isset( $GLOBALS['pagenow'] ) || $GLOBALS['pagenow'] !== 'options-writing.php' ) && $allow_users ) {
+			$user_options = get_user_option( 'classic-editor-settings' );
+
+			if ( $user_options === 'block' || $user_options === 'classic' ) {
+				$editor = $user_options;
+			}
+		}
+
+		self::$settings = array(
+			'editor' => $editor,
+			'hide-settings-ui' => false,
+			'allow-users' => $allow_users,
+		);
+
+		return self::$settings;
+	}
+
+	private static function is_classic( $post_id = 0 ) {
+		if ( ! $post_id ) {
+			$post_id = self::get_edited_post_id();
+		}
+
+		if ( $post_id ) {
+			$settings = self::get_settings();
+
+			if ( $settings['allow-users'] && ! isset( $_GET['classic-editor__forget'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$which = get_post_meta( $post_id, 'classic-editor-remember', true );
+
+				if ( $which ) {
+					// The editor choice will be "remembered" when the post is opened in either the classic or the block editor.
+					if ( 'classic-editor' === $which ) {
+						return true;
+					} elseif ( 'block-editor' === $which ) {
+						return false;
+					}
+				}
+
+				return ( ! self::has_blocks( $post_id ) );
+			}
+		}
+
+		if ( isset( $_GET['classic-editor'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the edited post ID (early) when loading the Edit Post screen.
+	 */
+	private static function get_edited_post_id() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if (
+			! empty( $_GET['post'] ) &&
+			! empty( $_GET['action'] ) &&
+			$_GET['action'] === 'edit' &&
+			! empty( $GLOBALS['pagenow'] ) &&
+			$GLOBALS['pagenow'] === 'post.php'
+		) {
+			return (int) $_GET['post']; // post_ID
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		return 0;
+	}
+
+	public static function register_settings() {
+		// Add an option to Settings -> Writing
+		register_setting( 'writing', 'classic-editor-replace', array(
+			'sanitize_callback' => array( __CLASS__, 'validate_option_editor' ),
+		) );
+
+		register_setting( 'writing', 'classic-editor-allow-users', array(
+			'sanitize_callback' => array( __CLASS__, 'validate_option_allow_users' ),
+		) );
+
+		$allowed_options = array(
+			'writing' => array(
+				'classic-editor-replace',
+				'classic-editor-allow-users'
+			),
+		);
+
+		if ( function_exists( 'add_allowed_options' ) ) {
+			add_allowed_options( $allowed_options );
+		} else {
+			add_option_whitelist( $allowed_options );
+		}
+
+		$heading_1 = __( 'Default editor for all users', 'classic-editor' );
+		$heading_2 = __( 'Allow users to switch editors', 'classic-editor' );
+
+		add_settings_field( 'classic-editor-1', $heading_1, array( __CLASS__, 'settings_1' ), 'writing' );
+		add_settings_field( 'classic-editor-2', $heading_2, array( __CLASS__, 'settings_2' ), 'writing' );
+	}
+
+	public static function save_user_settings( $user_id ) {
+		if (
+			isset( $_POST['classic-editor-user-settings'] ) &&
+			isset( $_POST['classic-editor-replace'] ) &&
+			wp_verify_nonce( $_POST['classic-editor-user-settings'], 'allow-user-settings' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		) {
+			$user_id = (int) $user_id;
+
+			if ( $user_id !== get_current_user_id() && ! current_user_can( 'edit_user', $user_id ) ) {
+				return;
+			}
+
+			$editor = self::validate_option_editor( $_POST['classic-editor-replace'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			update_user_option( $user_id, 'classic-editor-settings', $editor );
+		}
+	}
+
+	/**
+	 * Validate
+	 */
+	public static function validate_option_editor( $value ) {
+		if ( $value === 'block' ) {
+			return 'block';
+		}
+
+		return 'classic';
+	}
+
+	public static function validate_option_allow_users( $value ) {
+		if ( $value === 'allow' ) {
+			return 'allow';
+		}
+
+		return 'disallow';
+	}
+
+	public static function settings_1() {
+		$settings = self::get_settings( 'refresh' );
+
+		?>
+		<div class="classic-editor-options">
+			<p>
+				<input type="radio" name="classic-editor-replace" id="classic-editor-classic" value="classic"<?php if ( $settings['editor'] === 'classic' ) echo ' checked'; ?> />
+				<label for="classic-editor-classic"><?php _ex( 'Classic editor', 'Editor Name', 'classic-editor' ); ?></label>
+			</p>
+			<p>
+				<input type="radio" name="classic-editor-replace" id="classic-editor-block" value="block"<?php if ( $settings['editor'] !== 'classic' ) echo ' checked'; ?> />
+				<label for="classic-editor-block"><?php _ex( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
+			</p>
+		</div>
+		<script>
+		jQuery( 'document' ).ready( function( $ ) {
+			if ( window.location.hash === '#classic-editor-options' ) {
+				$( '.classic-editor-options' ).closest( 'td' ).addClass( 'highlight' );
+			}
+		} );
+		</script>
+		<?php
+	}
+
+	public static function settings_2() {
+		$settings = self::get_settings( 'refresh' );
+
+		?>
+		<div class="classic-editor-options">
+			<p>
+				<input type="radio" name="classic-editor-allow-users" id="classic-editor-allow" value="allow"<?php if ( $settings['allow-users'] ) echo ' checked'; ?> />
+				<label for="classic-editor-allow"><?php _e( 'Yes', 'classic-editor' ); ?></label>
+			</p>
+			<p>
+				<input type="radio" name="classic-editor-allow-users" id="classic-editor-disallow" value="disallow"<?php if ( ! $settings['allow-users'] ) echo ' checked'; ?> />
+				<label for="classic-editor-disallow"><?php _e( 'No', 'classic-editor' ); ?></label>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Shown on the Profile page when allowed by admin.
+	 */
+	public static function user_settings() {
+		global $user_can_edit;
+		$settings = self::get_settings( 'update' );
+
+		if (
+			! defined( 'IS_PROFILE_PAGE' ) ||
+			! IS_PROFILE_PAGE ||
+			! $user_can_edit ||
+			! $settings['allow-users']
+		) {
+			return;
+		}
+
+		?>
+		<table class="form-table">
+			<tr class="classic-editor-user-options">
+				<th scope="row"><?php _e( 'Default Editor', 'classic-editor' ); ?></th>
+				<td>
+				<?php wp_nonce_field( 'allow-user-settings', 'classic-editor-user-settings' ); ?>
+				<?php self::settings_1(); ?>
+				</td>
+			</tr>
+		</table>
+		<script>jQuery( 'tr.user-rich-editing-wrap' ).before( jQuery( 'tr.classic-editor-user-options' ) );</script>
+		<?php
+	}
+
+	public static function network_settings() {
+		$editor = get_network_option( null, 'classic-editor-replace' );
+		$is_checked = ( get_network_option( null, 'classic-editor-allow-sites' ) === 'allow' );
+
+		?>
+		<h2 id="classic-editor-options"><?php _e( 'Editor Settings', 'classic-editor' ); ?></h2>
+		<table class="form-table">
+			<?php wp_nonce_field( 'allow-site-admin-settings', 'classic-editor-network-settings' ); ?>
+			<tr>
+				<th scope="row"><?php _e( 'Default editor for all sites', 'classic-editor' ); ?></th>
+				<td>
+					<p>
+						<input type="radio" name="classic-editor-replace" id="classic-editor-classic" value="classic"<?php if ( $editor !== 'block' ) echo ' checked'; ?> />
+						<label for="classic-editor-classic"><?php _ex( 'Classic Editor', 'Editor Name', 'classic-editor' ); ?></label>
+					</p>
+					<p>
+						<input type="radio" name="classic-editor-replace" id="classic-editor-block" value="block"<?php if ( $editor === 'block' ) echo ' checked'; ?> />
+						<label for="classic-editor-block"><?php _ex( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
+					</p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php _e( 'Change settings', 'classic-editor' ); ?></th>
+				<td>
+					<input type="checkbox" name="classic-editor-allow-sites" id="classic-editor-allow-sites" value="allow"<?php if ( $is_checked ) echo ' checked'; ?>>
+					<label for="classic-editor-allow-sites"><?php _e( 'Allow site admins to change settings', 'classic-editor' ); ?></label>
+					<p class="description"><?php _e( 'By default the block editor is replaced with the classic editor and users cannot switch editors.', 'classic-editor' ); ?></p>
+				</td>
+			</tr>
+		</table>
+		<?php
+	}
+
+	public static function save_network_settings() {
+		if (
+			isset( $_POST['classic-editor-network-settings'] ) &&
+			current_user_can( 'manage_network_options' ) &&
+			wp_verify_nonce( $_POST['classic-editor-network-settings'], 'allow-site-admin-settings' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		) {
+			if ( isset( $_POST['classic-editor-replace'] ) && $_POST['classic-editor-replace'] === 'block' ) {
+				update_network_option( null, 'classic-editor-replace', 'block' );
+			} else {
+				update_network_option( null, 'classic-editor-replace', 'classic' );
+			}
+			if ( isset( $_POST['classic-editor-allow-sites'] ) && $_POST['classic-editor-allow-sites'] === 'allow' ) {
+				update_network_option( null, 'classic-editor-allow-sites', 'allow' );
+			} else {
+				update_network_option( null, 'classic-editor-allow-sites', 'disallow' );
+			}
+		}
+	}
+
+	/**
+	 * Add a hidden field in edit-form-advanced.php
+	 * to help redirect back to the classic editor on saving.
+	 */
+	public static function add_redirect_helper() {
+		?>
+		<input type="hidden" name="classic-editor" value="" />
+		<?php
+	}
+
+	/**
+	 * Remember when the classic editor was used to edit a post.
+	 */
+	public static function remember_classic_editor( $post ) {
+		$post_type = get_post_type( $post );
+
+		if ( $post_type && post_type_supports( $post_type, 'editor' ) ) {
+			self::remember( $post->ID, 'classic-editor' );
+		}
+	}
+
+	/**
+	 * Remember when the block editor was used to edit a post.
+	 */
+	public static function remember_block_editor( $editor_settings, $context ) {
+		if ( is_a( $context, 'WP_Post' ) ) {
+			$post = $context;
+		} elseif ( ! empty( $context->post ) ) {
+			$post = $context->post;
+		} else {
+			return $editor_settings;
+		}
+
+		$post_type = get_post_type( $post );
+
+		if ( $post_type && self::can_edit_post_type( $post_type ) ) {
+			self::remember( $post->ID, 'block-editor' );
+		}
+
+		return $editor_settings;
+	}
+
+	private static function remember( $post_id, $editor ) {
+		if ( get_post_meta( $post_id, 'classic-editor-remember', true ) !== $editor ) {
+			update_post_meta( $post_id, 'classic-editor-remember', $editor );
+		}
+	}
+
+	/**
+	 * Choose which editor to use for a post.
+	 *
+	 * Passes through `$which_editor` for block editor (it's sets to `true` but may be changed by another plugin).
+	 *
+	 * @uses `use_block_editor_for_post` filter.
+	 *
+	 * @param boolean $use_block_editor True for block editor, false for classic editor.
+	 * @param WP_Post $post             The post being edited.
+	 * @return boolean True for block editor, false for classic editor.
+	 */
+	public static function choose_editor( $use_block_editor, $post ) {
+		$settings = self::get_settings();
+		$editors = self::get_enabled_editors_for_post( $post );
+
+		// If no editor is supported, pass through `$use_block_editor`.
+		if ( ! $editors['block_editor'] && ! $editors['classic_editor'] ) {
+			return $use_block_editor;
+		}
+
+		// Open the default editor when no $post and for "Add New" links,
+		// or the alternate editor when the user is switching editors.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( empty( $post->ID ) || $post->post_status === 'auto-draft' ) {
+			if (
+				( $settings['editor'] === 'classic' && ! isset( $_GET['classic-editor__forget'] ) ) ||  // Add New
+				( isset( $_GET['classic-editor'] ) && isset( $_GET['classic-editor__forget'] ) ) // Switch to classic editor when no draft post.
+			) {
+				$use_block_editor = false;
+			}
+		} elseif ( self::is_classic( $post->ID ) ) {
+			$use_block_editor = false;
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		// Enforce the editor if set by plugins.
+		if ( $use_block_editor && ! $editors['block_editor'] ) {
+			$use_block_editor = false;
+		} elseif ( ! $use_block_editor && ! $editors['classic_editor'] && $editors['block_editor'] ) {
+			$use_block_editor = true;
+		}
+
+		return $use_block_editor;
+	}
+
+	/**
+	 * Keep the `classic-editor` query arg through redirects when saving posts.
+	 */
+	public static function redirect_location( $location ) {
+		if (
+			isset( $_REQUEST['classic-editor'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			( isset( $_POST['_wp_http_referer'] ) && strpos( $_POST['_wp_http_referer'], '&classic-editor' ) !== false ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing
+		) {
+			$location = add_query_arg( 'classic-editor', '', $location );
+		}
+
+		return $location;
+	}
+
+	/**
+	 * Keep the `classic-editor` query arg when looking at revisions.
+	 */
+	public static function get_edit_post_link( $url ) {
+		$settings = self::get_settings();
+
+		if ( isset( $_REQUEST['classic-editor'] ) || $settings['editor'] === 'classic' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$url = add_query_arg( 'classic-editor', '', $url );
+		}
+
+		return $url;
+	}
+
+	public static function add_meta_box( $post_type, $post ) {
+		$editors = self::get_enabled_editors_for_post( $post );
+
+		if ( ! $editors['block_editor'] || ! $editors['classic_editor'] ) {
+			// Editors cannot be switched.
+			return;
+		}
+
+		$id = 'classic-editor-switch-editor';
+		$title = __( 'Editor', 'classic-editor' );
+		$callback = array( __CLASS__, 'do_meta_box' );
+		$args = array(
+			'__back_compat_meta_box' => true,
+	    );
+
+		add_meta_box( $id, $title, $callback, null, 'side', 'default', $args );
+	}
+
+	public static function do_meta_box( $post ) {
+		$edit_url = get_edit_post_link( $post->ID, 'raw' );
+
+		// Switching to block editor.
+		$edit_url = remove_query_arg( 'classic-editor', $edit_url );
+		// Forget the previous value when going to a specific editor.
+		$edit_url = add_query_arg( 'classic-editor__forget', '', $edit_url );
+
+		?>
+		<p style="margin: 1em 0;">
+			<a href="<?php echo esc_url( $edit_url ); ?>"><?php _e( 'Switch to block editor', 'classic-editor' ); ?></a>
+		</p>
+		<?php
+	}
+
+	public static function enqueue_block_editor_scripts() {
+		// get_enabled_editors_for_post() needs a WP_Post or post_ID.
+		if ( empty( $GLOBALS['post'] ) ) {
+			return;
+		}
+
+		$editors = self::get_enabled_editors_for_post( $GLOBALS['post'] );
+
+		if ( ! $editors['classic_editor'] ) {
+			// Editor cannot be switched.
+			return;
+		}
+
+		wp_enqueue_script(
+			'classic-editor-plugin',
+			plugins_url( 'js/block-editor-plugin.js', __FILE__ ),
+			array( 'wp-element', 'wp-components', 'lodash' ),
+			'1.4',
+			true
+		);
+
+		wp_localize_script(
+			'classic-editor-plugin',
+			'classicEditorPluginL10n',
+			array( 'linkText' => __( 'Switch to classic editor', 'classic-editor' ) )
+		);
+	}
+
+	/**
+	 * Add a link to the settings on the Plugins screen.
+	 */
+	public static function add_settings_link( $links, $file ) {
+		$settings = self::get_settings();
+
+		if ( $file === 'classic-editor/classic-editor.php' && ! $settings['hide-settings-ui'] && current_user_can( 'manage_options' ) ) {
+			if ( current_filter() === 'plugin_action_links' ) {
+				$url = admin_url( 'options-writing.php#classic-editor-options' );
+			} else {
+				$url = admin_url( '/network/settings.php#classic-editor-options' );
+			}
+
+			// Prevent warnings in PHP 7.0+ when a plugin uses this filter incorrectly.
+			$links = (array) $links;
+			$links[] = sprintf( '<a href="%s">%s</a>', $url, __( 'Settings', 'classic-editor' ) );
+		}
+
+		return $links;
+	}
+
+	private static function can_edit_post_type( $post_type ) {
+		$can_edit = false;
+
+		if ( function_exists( 'gutenberg_can_edit_post_type' ) ) {
+			$can_edit = gutenberg_can_edit_post_type( $post_type );
+		} elseif ( function_exists( 'use_block_editor_for_post_type' ) ) {
+			$can_edit = use_block_editor_for_post_type( $post_type );
+		}
+
+		return $can_edit;
+	}
+
+	/**
+	 * Checks which editors are enabled for the post type.
+	 *
+	 * @param string $post_type The post type.
+	 * @return array Associative array of the editors and whether they are enabled for the post type.
+	 */
+	private static function get_enabled_editors_for_post_type( $post_type ) {
+		if ( isset( self::$supported_post_types[ $post_type ] ) ) {
+			return self::$supported_post_types[ $post_type ];
+		}
+
+		$classic_editor = post_type_supports( $post_type, 'editor' );
+		$block_editor = self::can_edit_post_type( $post_type );
+
+		$editors = array(
+			'classic_editor' => $classic_editor,
+			'block_editor'   => $block_editor,
+		);
+
+		/**
+		 * Filters the editors that are enabled for the post type.
+		 *
+		 * @param array $editors    Associative array of the editors and whether they are enabled for the post type.
+		 * @param string $post_type The post type.
+		 */
+		$editors = apply_filters( 'classic_editor_enabled_editors_for_post_type', $editors, $post_type );
+		self::$supported_post_types[ $post_type ] = $editors;
+
+		return $editors;
+	}
+
+	/**
+	 * Checks which editors are enabled for the post.
+	 *
+	 * @param WP_Post $post  The post object.
+	 * @return array Associative array of the editors and whether they are enabled for the post.
+	 */
+	private static function get_enabled_editors_for_post( $post ) {
+		$post_type = get_post_type( $post );
+
+		if ( ! $post_type ) {
+			return array(
+				'classic_editor' => false,
+				'block_editor'   => false,
+			);
+		}
+
+		$editors = self::get_enabled_editors_for_post_type( $post_type );
+
+		/**
+		 * Filters the editors that are enabled for the post.
+		 *
+		 * @param array $editors Associative array of the editors and whether they are enabled for the post.
+		 * @param WP_Post $post  The post object.
+		 */
+		return apply_filters( 'classic_editor_enabled_editors_for_post', $editors, $post );
+	}
+
+	/**
+	 * Adds links to the post/page screens to edit any post or page in
+	 * the classic editor or block editor.
+	 *
+	 * @param  array   $actions Post actions.
+	 * @param  WP_Post $post    Edited post.
+	 * @return array Updated post actions.
+	 */
+	public static function add_edit_links( $actions, $post ) {
+		// This is in Gutenberg, don't duplicate it.
+		if ( array_key_exists( 'classic', $actions ) ) {
+			unset( $actions['classic'] );
+		}
+
+		if ( ! array_key_exists( 'edit', $actions ) ) {
+			return $actions;
+		}
+
+		$edit_url = get_edit_post_link( $post->ID, 'raw' );
+
+		if ( ! $edit_url ) {
+			return $actions;
+		}
+
+		$editors = self::get_enabled_editors_for_post( $post );
+
+		// Do not show the links if only one editor is available.
+		if ( ! $editors['classic_editor'] || ! $editors['block_editor'] ) {
+			return $actions;
+		}
+
+		// Forget the previous value when going to a specific editor.
+		$edit_url = add_query_arg( 'classic-editor__forget', '', $edit_url );
+
+		// Build the edit actions. See also: WP_Posts_List_Table::handle_row_actions().
+		$title = _draft_or_post_title( $post->ID );
+
+		// Link to the block editor.
+		$url = remove_query_arg( 'classic-editor', $edit_url );
+		$text = _x( 'Edit (block editor)', 'Editor Name', 'classic-editor' );
+		/* translators: %s: post title */
+		$label = sprintf( __( 'Edit &#8220;%s&#8221; in the block editor', 'classic-editor' ), $title );
+		$edit_block = sprintf( '<a href="%s" aria-label="%s">%s</a>', esc_url( $url ), esc_attr( $label ), $text );
+
+		// Link to the classic editor.
+		$url = add_query_arg( 'classic-editor', '', $edit_url );
+		$text = _x( 'Edit (classic editor)', 'Editor Name', 'classic-editor' );
+		/* translators: %s: post title */
+		$label = sprintf( __( 'Edit &#8220;%s&#8221; in the classic editor', 'classic-editor' ), $title );
+		$edit_classic = sprintf( '<a href="%s" aria-label="%s">%s</a>', esc_url( $url ), esc_attr( $label ), $text );
+
+		$edit_actions = array(
+			'classic-editor-block' => $edit_block,
+			'classic-editor-classic' => $edit_classic,
+		);
+
+		// Insert the new Edit actions instead of the Edit action.
+		$edit_offset = array_search( 'edit', array_keys( $actions ), true );
+		array_splice( $actions, $edit_offset, 1, $edit_actions );
+
+		return $actions;
+	}
+
+	/**
+	 * Show the editor that will be used in a "post state" in the Posts list table.
+	 */
+	public static function add_post_state( $post_states, $post ) {
+		if ( get_post_status( $post ) === 'trash' ) {
+			return $post_states;
+		}
+
+		$editors = self::get_enabled_editors_for_post( $post );
+
+		if ( ! $editors['classic_editor'] && ! $editors['block_editor'] ) {
+			return $post_states;
+		} elseif ( $editors['classic_editor'] && ! $editors['block_editor'] ) {
+			// Forced to classic editor.
+			$state = '<span class="classic-editor-forced-state">' . _x( 'classic editor', 'Editor Name', 'classic-editor' ) . '</span>';
+		} elseif ( ! $editors['classic_editor'] && $editors['block_editor'] ) {
+			// Forced to block editor.
+			$state = '<span class="classic-editor-forced-state">' . _x( 'block editor', 'Editor Name', 'classic-editor' ) . '</span>';
+		} else {
+			$last_editor = get_post_meta( $post->ID, 'classic-editor-remember', true );
+
+			if ( $last_editor ) {
+				$is_classic = ( $last_editor === 'classic-editor' );
+			} elseif ( ! empty( $post->post_content ) ) {
+				$is_classic = ! self::has_blocks( $post->post_content );
+			} else {
+				$settings = self::get_settings();
+				$is_classic = ( $settings['editor'] === 'classic' );
+			}
+
+			$state = $is_classic ? _x( 'Classic editor', 'Editor Name', 'classic-editor' ) : _x( 'Block editor', 'Editor Name', 'classic-editor' );
+		}
+
+		// Fix PHP 7+ warnings if another plugin returns unexpected type.
+		$post_states = (array) $post_states;
+		$post_states['classic-editor-plugin'] = $state;
+
+		return $post_states;
+	}
+
+	public static function add_edit_php_inline_style() {
+		?>
+		<style>
+		.classic-editor-forced-state {
+			font-style: italic;
+			font-weight: 400;
+			color: #72777c;
+			font-size: small;
+		}
+		</style>
+		<?php
+	}
+
+	public static function on_admin_init() {
+		global $pagenow;
+
+		if ( $pagenow !== 'post.php' ) {
+			return;
+		}
+
+		$settings = self::get_settings();
+		$post_id = self::get_edited_post_id();
+
+		if ( $post_id && ( $settings['editor'] === 'classic' || self::is_classic( $post_id ) ) ) {
+			// Move the Privacy Policy help notice back under the title field.
+			remove_action( 'admin_notices', array( 'WP_Privacy_Policy_Content', 'notice' ) );
+			add_action( 'edit_form_after_title', array( 'WP_Privacy_Policy_Content', 'notice' ) );
+		}
+	}
+
+	// Need to support WP < 5.0
+	private static function has_blocks( $post = null ) {
+		if ( ! is_string( $post ) ) {
+			$wp_post = get_post( $post );
+
+			if ( $wp_post instanceof WP_Post ) {
+				$post = $wp_post->post_content;
+			}
+		}
+
+		return false !== strpos( (string) $post, '<!-- wp:' );
+	}
+
+	/**
+	 * Set defaults on activation.
+	 */
+	public static function activate() {
+		register_uninstall_hook( __FILE__, array( __CLASS__, 'uninstall' ) );
+
+		if ( is_multisite() ) {
+			add_network_option( null, 'classic-editor-replace', 'classic' );
+			add_network_option( null, 'classic-editor-allow-sites', 'disallow' );
+		}
+
+		add_option( 'classic-editor-replace', 'classic' );
+		add_option( 'classic-editor-allow-users', 'disallow' );
+	}
+
+	/**
+	 * Delete the options on uninstall.
+	 */
+	public static function uninstall() {
+		if ( is_multisite() ) {
+			delete_network_option( null, 'classic-editor-replace' );
+			delete_network_option( null, 'classic-editor-allow-sites' );
+		}
+
+		delete_option( 'classic-editor-replace' );
+		delete_option( 'classic-editor-allow-users' );
+	}
+}
+
+add_action( 'plugins_loaded', array( 'Classic_Editor', 'init_actions' ) );
+
+endif;

--- a/Plugin/classic-editor/js/block-editor-plugin.js
+++ b/Plugin/classic-editor/js/block-editor-plugin.js
@@ -1,0 +1,23 @@
+( function( wp ) {
+	if ( ! wp ) {
+		return;
+	}
+
+	wp.plugins.registerPlugin( 'classic-editor-plugin', {
+		render: function() {
+			var createElement = wp.element.createElement;
+			var PluginMoreMenuItem = wp.editPost.PluginMoreMenuItem;
+			var url = wp.url.addQueryArgs( document.location.href, { 'classic-editor': '', 'classic-editor__forget': '' } );
+			var linkText = lodash.get( window, [ 'classicEditorPluginL10n', 'linkText' ] ) || 'Switch to classic editor';
+
+			return createElement(
+				PluginMoreMenuItem,
+				{
+					icon: 'editor-kitchensink',
+					href: url,
+				},
+				linkText
+			);
+		},
+	} );
+} )( window.wp );

--- a/Plugin/classic-editor/readme.txt
+++ b/Plugin/classic-editor/readme.txt
@@ -1,0 +1,138 @@
+=== Classic Editor ===
+Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pento, youknowriad, desrosj, luciano-croce
+Tags: gutenberg, disable, disable gutenberg, editor, classic editor, block editor
+Requires at least: 4.9
+Tested up to: 6.2
+Stable tag: 1.6.3
+Requires PHP: 5.2.4
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Enables the previous "classic" editor and the old-style Edit Post screen with TinyMCE, Meta Boxes, etc. Supports all plugins that extend this screen.
+
+== Description ==
+
+Classic Editor is an official plugin maintained by the WordPress team that restores the previous ("classic") WordPress editor and the "Edit Post" screen. It makes it possible to use plugins that extend that screen, add old-style meta boxes, or otherwise depend on the previous editor.
+
+Classic Editor is an official WordPress plugin, and will be fully supported and maintained until 2024, or as long as is necessary.
+
+At a glance, this plugin adds the following:
+
+* Administrators can select the default editor for all users.
+* Administrators can allow users to change their default editor.
+* When allowed, the users can choose which editor to use for each post.
+* Each post opens in the last editor used regardless of who edited it last. This is important for maintaining a consistent experience when editing content.
+
+In addition, the Classic Editor plugin includes several filters that let other plugins control the settings, and the editor choice per post and per post type.
+
+By default, this plugin hides all functionality available in the new block editor ("Gutenberg").
+
+== Changelog ==
+
+= 1.6.3 =
+* Added some WPCS fixes, props NicktheGeek on GitHub.
+* Updated "Tested up to" in the readme and removed it from classic-editor.php. This should fix false positive errors in security plugins in the future.
+
+= 1.6.2 =
+* Fixed bug that was preventing saving of the last used editor.
+
+= 1.6.1 =
+* Fixed a warning on the block editor based widgets screen.
+* Fixed use of a deprecated filter.
+
+= 1.6 =
+* Updated for WordPress 5.5.
+* Fixed minor issues with calling deprecated functions, needlessly registering uninstall hook, and capitalization of some strings.
+
+= 1.5 =
+* Updated for WordPress 5.2 and Gutenberg 5.3.
+* Enhanced and fixed the "open posts in the last editor used to edit them" logic.
+* Fixed adding post state so it can easily be accessed from other plugins.
+
+= 1.4 =
+* On network installations removed the restriction for only network activation.
+* Added support for network administrators to choose the default network-wide editor.
+* Fixed the settings link in the warning on network About screen.
+* Properly added the "Switch to classic editor" menu item to the block editor menu.
+
+= 1.3 =
+* Fixed removal of the "Try Gutenberg" dashboard widget.
+* Fixed condition for displaying of the after upgrade notice on the "What's New" screen. Shown when the classic editor is selected and users cannot switch editors.
+
+= 1.2 =
+* Fixed switching editors from the Add New (post) screen before a draft post is saved.
+* Fixed typo that was appending the edit URL to the `classic-editor` query var.
+* Changed detecting of WordPress 5.0 to not use version check. Fixes a bug when testing 5.1-alpha.
+* Changed the default value of the option to allow users to switch editors to false.
+* Added disabling of the Gutenberg plugin and lowered the required WordPress version to 4.9.
+* Added `classic_editor_network_default_settings` filter.
+
+= 1.1 =
+Fixed a bug where it may attempt to load the block editor for post types that do not support editor when users are allowed to switch editors.
+
+= 1.0 =
+* Updated for WordPress 5.0.
+* Changed all "Gutenberg" names/references to "block editor".
+* Refreshed the settings UI.
+* Removed disabling of the Gutenberg plugin. This was added for testing in WordPress 4.9. Users who want to continue following the development of Gutenberg in WordPress 5.0 and beyond will not need another plugin to disable it.
+* Added support for per-user settings of default editor.
+* Added support for admins to set the default editor for the site.
+* Added support for admins to allow users to change their default editor.
+* Added support for network admins to prevent site admins from changing the default settings.
+* Added support to store the last editor used for each post and open it next time. Enabled when users can choose default editor.
+* Added "post editor state" in the listing of posts on the Posts screen. Shows the editor that will be opened for the post. Enabled when users can choose default editor.
+* Added `classic_editor_enabled_editors_for_post` and `classic_editor_enabled_editors_for_post_type` filters. Can be used by other plugins to control or override the editor used for a particular post of post type.
+* Added `classic_editor_plugin_settings` filter. Can be used by other plugins to override the settings and disable the settings UI.
+
+= 0.5 =
+* Updated for Gutenberg 4.1 and WordPress 5.0-beta1.
+* Removed some functionality that now exists in Gutenberg.
+* Fixed redirecting back to the classic editor after looking at post revisions.
+
+= 0.4 =
+* Fixed removing of the "Try Gutenberg" call-out when the Gutenberg plugin is not activated.
+* Fixed to always show the settings and the settings link in the plugins list table.
+* Updated the readme text.
+
+= 0.3 =
+* Updated the option from a checkbox to couple of radio buttons, seems clearer. Thanks to @designsimply for the label text suggestions.
+* Some general updates and cleanup.
+
+= 0.2 =
+* Update for Gutenberg 1.9.
+* Remove warning and automatic deactivation when Gutenberg is not active.
+
+= 0.1 =
+Initial release.
+
+== Frequently Asked Questions ==
+
+= Default settings =
+
+When activated and when using a classic (non-block) theme, this plugin will restore the previous ("classic") WordPress editor and hide the new block editor ("Gutenberg").
+These settings can be changed at the Settings => Writing screen.
+
+= Default settings for network installation =
+
+There are two options:
+
+* When network-activated and when using a classic (non-block) theme, this plugin will set the classic editor as default and prevent site administrators and users from changing editors.
+The settings can be changed and default network-wide editor can be selected on the Network Settings screen.
+* When not network-activated each site administrator will be able to activate the plugin and choose options for their users.
+
+= Cannot find the "Switch to classic editor" link =
+
+It is in the main block editor menu, see this [screenshot](https://ps.w.org/classic-editor/assets/screenshot-7.png?rev=2023480).
+
+= Does this work with full site editing and block themes? =
+
+No, as block themes rely on blocks. [See Block themes article](https://wordpress.org/support/article/block-themes/) for more information.
+
+== Screenshots ==
+1. Admin settings on the Settings -> Writing screen.
+2. User settings on the Profile screen. Visible when the users are allowed to switch editors.
+3. "Action links" to choose alternative editor. Visible when the users are allowed to switch editors.
+4. Link to switch to the block editor while editing a post in the classic editor. Visible when the users are allowed to switch editors.
+5. Link to switch to the classic editor while editing a post in the block editor. Visible when the users are allowed to switch editors.
+6. Network settings to select the default editor for the network and allow site admins to change it.
+7. The "Switch to classic editor" link.


### PR DESCRIPTION
Changes from WordPress Playground

Also exported as a zip file.

* [Preview loaded from this PR – available **before** this PR is merged](https://playground.wordpress.net/?import-site=https%3A%2F%2Fraw.githubusercontent.com%2FBaalMcKloud%2FWP-TEST%2Fplayground-changes-2023-12-11T23-51-28-366Z%2FPlugin%2Fclassic-editor%2Fplayground.zip)
* [Preview loaded from the main branch – available **after** this PR is merged](https://playground.wordpress.net/?import-site=https%3A%2F%2Fraw.githubusercontent.com%2FBaalMcKloud%2FWP-TEST%2Fmain%2FPlugin%2Fclassic-editor%2Fplayground.zip)